### PR TITLE
Include to fix build

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,7 @@
 #include <librealsense2/rs.hpp> // Include RealSense Cross Platform API
 #include <opencv2/opencv.hpp>   // Include OpenCV API
 #include <opencv2/rgbd.hpp>     // OpenCV RGBD Contrib package
+#include <opencv2/highgui/highgui_c.h> // OpenCV High-level GUI
 
 // STD
 #include <string>


### PR DESCRIPTION
cvGetWindowHandle was not found but it was in the header I added, perhaps opencv changed their api. 